### PR TITLE
feat: add endpoints para listar glicemias e consultar glicemias por id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+run:
+	uvicorn main:app --reload
+
 test:
 	pytest -vv tests/
 

--- a/contextos/glicemias/pontos_de_entrada/api.py
+++ b/contextos/glicemias/pontos_de_entrada/api.py
@@ -96,6 +96,35 @@ def listar_glicemias() -> List[Glicemia]:
     )
 
 
+@router.get(
+    "/v1/glicemias/{glicemia_id}",
+    status_code=200,
+    response_model=RetornoDeConsultaGlicemiasAPI,
+)
+def consultar_glicemias_por_id(glicemia_id: UUID) -> Glicemia:
+    usuario_id = uuid4()
+
+    uow = SqlAlchemyUnitOfWork()
+
+    glicemia = consultar_glicemia_por_id(
+        glicemia_id=glicemia_id,
+        usuario_id=usuario_id,
+        uow=uow,
+    )
+
+    return RetornoDeConsultaGlicemiasAPI(
+        glicemias=[
+            GlicemiaAPI(
+                id=glicemia.id,
+                valor=glicemia.valor,
+                observacoes=glicemia.observacoes,
+                primeira_do_dia=glicemia.primeira_do_dia,
+                horario_dosagem=glicemia.horario_dosagem,
+            )
+        ]
+    )
+
+
 @router.post(
     "/v1/glicemias",
     status_code=201,

--- a/contextos/glicemias/pontos_de_entrada/api.py
+++ b/contextos/glicemias/pontos_de_entrada/api.py
@@ -1,8 +1,11 @@
 from uuid import UUID, uuid4
 
+from typing import List
 from fastapi import FastAPI
 from datetime import datetime
 from pydantic import BaseModel, Extra
+
+from contextos.glicemias.dominio.entidades import Glicemia
 
 from contextos.glicemias.dominio.comandos import (
     CriarGlicemia,
@@ -13,6 +16,10 @@ from contextos.glicemias.servicos.executores import (
     criar_glicemia,
     editar_glicemia,
     remover_glicemia,
+)
+from contextos.glicemias.servicos.visualizadores import (
+    consultar_glicemias,
+    consultar_glicemia_por_id,
 )
 from contextos.glicemias.dominio.objetos_de_valor import ValoresParaEdicaoDeGlicemia
 
@@ -44,6 +51,28 @@ class ValoresParaEdicaoDeGlicemiaAPI(BaseModel):
 
 class RetornoDeGlicemiasAPI(BaseModel):
     id: UUID
+
+
+class RetornoDeConsultaGlicemiasAPI(BaseModel):
+    glicemias: List[Glicemia]
+
+
+@app.get(
+    "/v1/glicemias",
+    response_model=RetornoDeConsultaGlicemiasAPI,
+    status_code=200,
+)
+def listar_glicemias():
+    usuario_id = uuid4()
+
+    uow = SqlAlchemyUnitOfWork()
+
+    glicemias = consultar_glicemias(
+        usuario_id=usuario_id,
+        uow=uow,
+    )
+
+    return RetornoDeConsultaGlicemiasAPI(glicemias=glicemias)
 
 
 @app.post(

--- a/contextos/glicemias/servicos/unidade_de_trabalho.py
+++ b/contextos/glicemias/servicos/unidade_de_trabalho.py
@@ -16,7 +16,8 @@ class AbstractUnitOfWork(abc.ABC):
         return self
 
     def __exit__(self, *args):
-        self.rollback()
+        # self.rollback()
+        pass
 
     @abc.abstractmethod
     def commit(self):

--- a/main.py
+++ b/main.py
@@ -1,14 +1,7 @@
-from typing import Optional
 from fastapi import FastAPI
+
+from contextos.glicemias.pontos_de_entrada.api import router as router_glicemias
 
 app = FastAPI()
 
-
-@app.get("/")
-def read_root():
-    return {"hello": "world"}
-
-
-@app.get("/items/{item_id}")
-def read_item(item_id: int, q: Optional[str] = None):
-    return {"item_id": item_id, "q": q}
+app.include_router(router_glicemias)

--- a/tests/contextos/glicemias/pontos_de_entrada/test_api.py
+++ b/tests/contextos/glicemias/pontos_de_entrada/test_api.py
@@ -4,9 +4,9 @@ from freezegun import freeze_time
 from datetime import datetime, timedelta
 from fastapi.testclient import TestClient
 
-from contextos.glicemias.pontos_de_entrada.api import app
-
 from contextos.glicemias.dominio.entidades import Glicemia
+
+from main import app
 
 client = TestClient(app)
 
@@ -50,8 +50,8 @@ def test_consultar_glicemias(session):
 
     response = client.get("/v1/glicemias")
 
-    assert response.status_code == 201
-    assert list(response.json().get("glicemias")) == 3
+    assert response.status_code == 200
+    assert len(response.json().get("glicemias")) == 3
 
 
 @freeze_time(datetime(2021, 8, 27, 16, 20))


### PR DESCRIPTION
Adiciona endpoints para listar glicemias e consultar glicemias por id.

Além disso, o pull request também:

- Altera estrutura da API para poder comportar vários routers
- Utiliza o `router` nos `pontos_de_entrada` do contexto de `glicemias`
- Altera a unidade de trabalho abstrata para não chamar o método `rollback` no método mágico `exit`